### PR TITLE
Configuration parameter for alternative scan folder

### DIFF
--- a/src/main/java/de/ito/gradle/plugin/androidstringextractor/AndroidStringExtractorPlugin.java
+++ b/src/main/java/de/ito/gradle/plugin/androidstringextractor/AndroidStringExtractorPlugin.java
@@ -8,28 +8,29 @@ import org.gradle.api.Project;
  */
 class AndroidStringExtractorPluginExtension {
 
-    public AndroidStringExtractorPluginExtension() {}
+  String targetFolder;
 
-    String targetFolder;
+  public AndroidStringExtractorPluginExtension() {
+  }
 
-    public void setTargetFolder(String targetFolder) {
-        this.targetFolder = targetFolder;
-    }
+  public String getTargetFolder() {
+    return targetFolder;
+  }
 
-    public String getTargetFolder() {
-        return targetFolder;
-    }
+  public void setTargetFolder(String targetFolder) {
+    this.targetFolder = targetFolder;
+  }
 }
 
 public class AndroidStringExtractorPlugin implements Plugin<Project> {
 
-    static final String TASK_NAME = "extractStringsFromLayouts";
+  static final String TASK_NAME = "extractStringsFromLayouts";
 
-    @Override
-    public void apply(Project target) {
-        AndroidStringExtractorPluginExtension extractionProperties =
-                target.getExtensions().create("stringExtractionProperties", AndroidStringExtractorPluginExtension.class);
-        AndroidStringExtractorTask androidStringExtractorTask = target.getTasks().create(TASK_NAME, AndroidStringExtractorTask.class);
-        androidStringExtractorTask.doFirst(task -> ((AndroidStringExtractorTask) task).setOtherProjectDir(extractionProperties.targetFolder));
-    }
+  @Override
+  public void apply(Project target) {
+    AndroidStringExtractorPluginExtension extractionProperties =
+        target.getExtensions().create("stringExtractionProperties", AndroidStringExtractorPluginExtension.class);
+    AndroidStringExtractorTask androidStringExtractorTask = target.getTasks().create(TASK_NAME, AndroidStringExtractorTask.class);
+    androidStringExtractorTask.doFirst(task -> ((AndroidStringExtractorTask) task).setOtherProjectDir(extractionProperties.targetFolder));
+  }
 }

--- a/src/main/java/de/ito/gradle/plugin/androidstringextractor/AndroidStringExtractorPlugin.java
+++ b/src/main/java/de/ito/gradle/plugin/androidstringextractor/AndroidStringExtractorPlugin.java
@@ -29,8 +29,12 @@ public class AndroidStringExtractorPlugin implements Plugin<Project> {
   @Override
   public void apply(Project target) {
     AndroidStringExtractorPluginExtension extractionProperties =
-        target.getExtensions().create("stringExtractionProperties", AndroidStringExtractorPluginExtension.class);
-    AndroidStringExtractorTask androidStringExtractorTask = target.getTasks().create(TASK_NAME, AndroidStringExtractorTask.class);
-    androidStringExtractorTask.doFirst(task -> ((AndroidStringExtractorTask) task).setOtherProjectDir(extractionProperties.targetFolder));
+        target.getExtensions()
+            .create("stringExtractionProperties", AndroidStringExtractorPluginExtension.class);
+    AndroidStringExtractorTask androidStringExtractorTask =
+        target.getTasks().create(TASK_NAME, AndroidStringExtractorTask.class);
+    androidStringExtractorTask.doFirst(
+        task -> ((AndroidStringExtractorTask) task).setOtherProjectDir(
+            extractionProperties.targetFolder));
   }
 }

--- a/src/main/java/de/ito/gradle/plugin/androidstringextractor/AndroidStringExtractorPlugin.java
+++ b/src/main/java/de/ito/gradle/plugin/androidstringextractor/AndroidStringExtractorPlugin.java
@@ -3,12 +3,33 @@ package de.ito.gradle.plugin.androidstringextractor;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
+/**
+ * Class containing the parameters of the plugin.
+ */
+class AndroidStringExtractorPluginExtension {
+
+    public AndroidStringExtractorPluginExtension() {}
+
+    String targetFolder;
+
+    public void setTargetFolder(String targetFolder) {
+        this.targetFolder = targetFolder;
+    }
+
+    public String getTargetFolder() {
+        return targetFolder;
+    }
+}
+
 public class AndroidStringExtractorPlugin implements Plugin<Project> {
 
-  static final String TASK_NAME = "extractStringsFromLayouts";
+    static final String TASK_NAME = "extractStringsFromLayouts";
 
-  @Override
-  public void apply(Project target) {
-      target.getTasks().create(TASK_NAME, AndroidStringExtractorTask.class);
-  }
+    @Override
+    public void apply(Project target) {
+        AndroidStringExtractorPluginExtension extractionProperties =
+                target.getExtensions().create("stringExtractionProperties", AndroidStringExtractorPluginExtension.class);
+        AndroidStringExtractorTask androidStringExtractorTask = target.getTasks().create(TASK_NAME, AndroidStringExtractorTask.class);
+        androidStringExtractorTask.doFirst(task -> ((AndroidStringExtractorTask) task).setOtherProjectDir(extractionProperties.targetFolder));
+    }
 }

--- a/src/main/java/de/ito/gradle/plugin/androidstringextractor/AndroidStringExtractorTask.java
+++ b/src/main/java/de/ito/gradle/plugin/androidstringextractor/AndroidStringExtractorTask.java
@@ -7,21 +7,21 @@ import org.gradle.api.tasks.TaskAction;
 
 public class AndroidStringExtractorTask extends DefaultTask {
 
-    private final LayoutStringExtractor layoutStringExtractor;
+  private final LayoutStringExtractor layoutStringExtractor;
 
-    private String otherProjectDir;
+  private String otherProjectDir;
 
-    public AndroidStringExtractorTask() {
-        layoutStringExtractor = new LayoutStringExtractor(new AndroidProjectFactory());
-    }
+  public AndroidStringExtractorTask() {
+    layoutStringExtractor = new LayoutStringExtractor(new AndroidProjectFactory());
+  }
 
-    @TaskAction
-    public void extractStringsFromLayouts() throws Exception {
-        String projectPath = otherProjectDir == null ? getProject().getProjectDir().getPath() : otherProjectDir;
-        layoutStringExtractor.extract(projectPath);
-    }
+  @TaskAction
+  public void extractStringsFromLayouts() throws Exception {
+    String projectPath = otherProjectDir == null ? getProject().getProjectDir().getPath() : otherProjectDir;
+    layoutStringExtractor.extract(projectPath);
+  }
 
-    void setOtherProjectDir(String otherProjectDir) {
-        this.otherProjectDir = otherProjectDir;
-    }
+  void setOtherProjectDir(String otherProjectDir) {
+    this.otherProjectDir = otherProjectDir;
+  }
 }

--- a/src/main/java/de/ito/gradle/plugin/androidstringextractor/AndroidStringExtractorTask.java
+++ b/src/main/java/de/ito/gradle/plugin/androidstringextractor/AndroidStringExtractorTask.java
@@ -7,15 +7,21 @@ import org.gradle.api.tasks.TaskAction;
 
 public class AndroidStringExtractorTask extends DefaultTask {
 
-  private final LayoutStringExtractor layoutStringExtractor;
+    private final LayoutStringExtractor layoutStringExtractor;
 
-  public AndroidStringExtractorTask() {
-    layoutStringExtractor = new LayoutStringExtractor(new AndroidProjectFactory());
-  }
+    private String otherProjectDir;
 
-  @TaskAction
-  public void extractStringsFromLayouts() throws Exception {
-    String projectPath = getProject().getProjectDir().getPath();
-    layoutStringExtractor.extract(projectPath);
-  }
+    public AndroidStringExtractorTask() {
+        layoutStringExtractor = new LayoutStringExtractor(new AndroidProjectFactory());
+    }
+
+    @TaskAction
+    public void extractStringsFromLayouts() throws Exception {
+        String projectPath = otherProjectDir == null ? getProject().getProjectDir().getPath() : otherProjectDir;
+        layoutStringExtractor.extract(projectPath);
+    }
+
+    void setOtherProjectDir(String otherProjectDir) {
+        this.otherProjectDir = otherProjectDir;
+    }
 }


### PR DESCRIPTION
It would be nice to have some configuration option which allows to scan and extract resource strings from another directory besides the default directory.

This pull request allows to specify a different directory on which the scan is supposed to happen. With the changes introduced in this pull request you include in your `build.gradle` file your classpath declaration:

    classpath 'de.ito.gradle.plugin:android-string-extractor:0.1.1'

and then for scanning the `app` folder (as an example) you can add this configuration to your `build.gradle` file:

```
stringExtractionProperties {
    targetFolder = 'app'
}
```


